### PR TITLE
listener CI workflow -> trying to cache go build to speed up

### DIFF
--- a/.github/workflows/k6-build-act-local.yaml
+++ b/.github/workflows/k6-build-act-local.yaml
@@ -1,13 +1,13 @@
 #workflow for local test with act (ref: https://github.com/nektos/act)
 #just removing the final checksum check (fails in this local actions runner)
-name: Build Listener Image (locally - act) 
-run-name: listener image build on ${{ github.event_name }} by ${{ github.actor }}
+name: Build K6 Image (locally - act) 
+run-name: k6 image build on ${{ github.event_name }} by ${{ github.actor }}
 on:  
   workflow_dispatch:
     
 jobs:
-  build-listener-local:
-    name: Push Listener's Image to DockerHub
+  build-k6-local:
+    name: Push K6's Image to DockerHub
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -28,22 +28,18 @@ jobs:
         id: extractor
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.LISTENER_IMAGE }}
-
+          images: ${{ secrets.K6_IMAGE }}
+          labels: |
+            org.opencontainers.image.description=updated on $(date +'%Y-%m-%d') - K6 load testing tool to work with logcore-v2 project (makes MQTT calls to verne-broker)
+          
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6
         with:
-          context: ./src/services/listener
-          file: ./src/services/listener/Dockerfile
+          context: ./src/services/k6
+          file: ./src/services/k6/Dockerfile
           push: true
           tags: |
-            sardinesszsz/verne-listener:latest 
+            sardinesszsz/k6-verne:latest 
           labels: ${{ steps.extractor.outputs.labels }}
       
-      # - name: Generate artifact attestation
-      #   uses: actions/attest-build-provenance@v3
-      #   with:
-      #     subject-name: index.docker.io/${{ secrets.LISTENER_IMAGE }}
-      #     subject-digest: ${{ steps.push.outputs.digest }}
-      #     push-to-registry: true

--- a/.github/workflows/listener-build-image.yaml
+++ b/.github/workflows/listener-build-image.yaml
@@ -20,6 +20,14 @@ jobs:
     steps: 
       - name: Check out the repo
         uses: actions/checkout@v5
+
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -43,6 +51,8 @@ jobs:
           tags: |
             sardinesszsz/verne-listener:latest 
           labels: ${{ steps.extractor.outputs.labels }}
+
+      
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v3

--- a/src/services/listener/Dockerfile
+++ b/src/services/listener/Dockerfile
@@ -4,7 +4,9 @@ WORKDIR /app
 
 COPY go.mod go.sum ./
 RUN go mod download
-COPY . .
+COPY main.go ./  
+COPY utils/ ./utils/  
+
 
 RUN go build -o listenerproc
 


### PR DESCRIPTION
- k6 build takes ~20 sec, while listener takes ~1 min, so gonna cache go mods, maybe that might speed things up a bit